### PR TITLE
chore/deps: no longer import libwinpthread-1.dll

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -48,7 +48,6 @@ export const CONFIG = {
 };
 
 export const LIB_PATH = {
-    PTHREAD   : './libwinpthread-1.dll',
     SAFE_AUTH : {
         win32  : './safe_authenticator.dll',
         darwin : './libsafe_authenticator.dylib',

--- a/app/extensions/safe/ffi/lib.js
+++ b/app/extensions/safe/ffi/lib.js
@@ -44,10 +44,6 @@ class LibLoader {
 
     return new Promise((resolve, reject) => {
       try {
-        if (os.platform() === 'win32') {
-          ffi.DynamicLibrary(path.resolve(__dirname, CONSTANTS.LIB_PATH.PTHREAD), mode);
-        }
-
         const lib = ffi.DynamicLibrary(path.resolve(__dirname, this[_libPath]), mode);
         Object.keys(ffiFunctions).forEach((fnName) => {
           fnDefinition = ffiFunctions[fnName];

--- a/app/package.json
+++ b/app/package.json
@@ -50,21 +50,6 @@
           "filename": "safe_authenticator-mock",
           "targetDir": "extensions/safe/dist"
         }
-      },
-      "win32": {
-        "libwinpthread-1": {
-          "mirror": "https://s3.eu-west-2.amazonaws.com/libwinpthread",
-          "version": "v0.1.0",
-          "targetDir": "extensions/safe/dist",
-          "filePattern": "^libwinpthread-1.dll$"
-        },
-        "ENV": {
-          "test": {
-            "libwinpthread-1": {
-              "targetDir": "extensions/safe/dist"
-            }
-          }
-        }
       }
     }
   },


### PR DESCRIPTION
Tested successfully on Windows 10 by executing browser, visiting safe sites, and interacting with network with API playground.