### PR TITLE
MAID-2488 feat/webFetch: impl multipart range requests

### DIFF
--- a/app/extensions/safe/utils/safeHelpers.js
+++ b/app/extensions/safe/utils/safeHelpers.js
@@ -27,3 +27,69 @@ export const urlIsAllowed = ( testUrl ) =>
 
     return false;
 };
+
+export const generateBoundaryStr = () => 
+{
+    let text = '';
+    const charSet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    
+    for (let i = 0; i < 13; i++) {
+      text += charSet.charAt(Math.floor(Math.random() * charSet.length));
+    }
+    
+    return text;
+};
+
+export const rangeStringToArray = (rangeString) => 
+{
+    const BYTES = 'bytes=';
+    return rangeString.substring( BYTES.length, rangeString.length )
+      .split( ',' )
+      .map(part => 
+      {
+          const partObj = {}; 
+          part.split('-')
+              .forEach((int, i) => 
+              {
+                if (i === 0) 
+                {
+                  if ( Number.isInteger(parseInt(int, 10)) )
+                  {
+                    partObj.start = parseInt(int, 10);
+                  }
+                  else
+                  {
+                    partObj.start = null;
+                  }
+                }
+                else if (i === 1) 
+                {
+                  if ( Number.isInteger(parseInt(int, 10)) )
+                  {
+                    partObj.end = parseInt(int, 10);
+                  }
+                  else
+                  {
+                    partObj.end = null;
+                  }
+                }
+              });
+          return partObj;
+      });
+};
+
+export const generateResponseStr = (data) => {
+  const boundaryStr = generateBoundaryStr();
+  const crlf = "\r\n";
+  let responseStr = `HTTP/1.1 206 Partial Content${crlf}`;
+  responseStr += `Content-Type: multipart/byteranges; boundary=${boundaryStr}${crlf}`;
+  responseStr += `Content-Length:${data.headers['Content-Length']}${crlf}`;
+  data.parts.forEach((part) => {
+    responseStr += `--${boundaryStr}${crlf}`;
+    responseStr += `Content-Type:${part.headers['Content-Type']}${crlf}`;
+    responseStr += `Content-Range: ${part.headers['Content-Range']}${crlf}`;
+    responseStr += `${part.body}${crlf}`;
+  });
+  responseStr += `--${boundaryStr}--`;
+  return responseStr;
+};

--- a/test/extensions/safe/safeHelpers.spec.js
+++ b/test/extensions/safe/safeHelpers.spec.js
@@ -1,4 +1,4 @@
-import {urlIsAllowed} from 'extensions/safe/utils/safeHelpers';
+import {urlIsAllowed, generateBoundaryStr, generateResponseStr, rangeStringToArray } from 'extensions/safe/utils/safeHelpers';
 
 describe( 'Safe Extension', () =>
 {
@@ -36,4 +36,88 @@ describe( 'Safe Extension', () =>
             expect( urlIsAllowed( home ) ).toBeTruthy();
         } );
     });
+
+    describe( 'Generate boundary string for multirange server response header', () =>
+    {
+        test('it exists', () => 
+        {
+            expect( generateBoundaryStr ).not.toBeNull();
+        } ); 
+
+        test('it generates 13 character string', () => 
+        {
+            const testValue = generateBoundaryStr();
+            expect( testValue.length ).toBe(13);
+            expect( typeof testValue).toBe('string');
+        } ); 
+    } ); 
+
+    describe( 'Generate response string for multirange server response', () =>
+    {
+        test('it exists', () => 
+        {
+            expect( generateResponseStr ).not.toBeNull();
+        } ); 
+
+        test('returns response string', () => 
+        {
+            const fileData = Buffer.from('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
+            const parts =
+            [
+              {
+                body: fileData.slice(3, 9),
+                headers: {
+                  'Content-Type': 'text/plain',
+                  'Content-Range': `bytes 3-8/${fileData.length}`
+                }
+              },
+              {
+                body: fileData.slice(11, 14),
+                headers: {
+                  'Content-Type': 'text/plain',
+                  'Content-Range': `bytes 11-13/${fileData.length}`
+                }
+              },
+              {
+                body: fileData.slice(17, 19),
+                headers: {
+                  'Content-Type': 'text/plain',
+                  'Content-Range': `bytes 17-18/${fileData.length}`
+                }
+              }
+            ];
+            const data = 
+            {
+              headers: 
+              {
+                'Content-Type': 'multipart/byteranges',
+                'Content-Length': JSON.stringify(parts).length
+              },
+              parts
+            };
+            const testValue = generateResponseStr(data);
+            expect( typeof testValue).toBe('string');
+        } ); 
+    } ); 
+
+    describe( 'Parse range request string as array of range objects', () =>
+    {
+        test('it exists', () => 
+        {
+            expect( rangeStringToArray ).not.toBeNull();
+        } ); 
+
+        test('returns array of range objects', () => 
+        {
+            const rangeString = 'bytes=4-6,14-20,40-53';
+            const testValue = rangeStringToArray(rangeString);
+            const expectedValue = 
+            [
+              { start: 4, end: 6 },
+              { start: 14, end: 20 },
+              { start: 40, end: 53 }
+            ];
+            expect( testValue ).toEqual(expectedValue);
+        } ); 
+    } ); 
 } );


### PR DESCRIPTION
See commit, https://github.com/joshuef/peruse/commit/dff8f2151570be8cefce19bfb0f93baf31c1870c, of this PR and also https://github.com/maidsafe/safe_app_nodejs/pull/223

When making a multipart range request with `webFetch` Peruse will receive a response as follows:
```{
  "headers": {
       "Content-Type": "multipart/byteranges",
       "Content-Length": 200
   }.
   parts: [
       {
           "headers": {
                "Content-Type: "video/mp4,
                "Content-Range":  bytes 4-15/200
            },
            body: <Buffer>
       },
        {
           "headers": {
                "Content-Type: "video/mp4,
                "Content-Range":  bytes 40-99/200
            },
            body: <Buffer>
       },
        {
           "headers": {
                "Content-Type: "video/mp4,
                "Content-Range":  bytes 150-175/200
            },
            body: <Buffer>
       },
   ]
}
```