### PR TITLE
[WIP]MAID-2688 chore/connectivity: enable reconnect for Peruse app and update state on network status

### DIFF
--- a/app/extensions/safe/network/authenticator-comms.js
+++ b/app/extensions/safe/network/authenticator-comms.js
@@ -33,6 +33,8 @@ export const authFromInternalResponse = async ( res, isAuthenticated ) =>
     {
         // for webFetch app only
         peruseAppObj = await peruseAppObj.auth.loginFromUri( res );
+        // When running function below, error is thrown that lib.test_simulate_network_disconnect is not a function
+        //peruseAppObj.auth.simulateNetworkDisconnect();
     }
     catch ( err )
     {
@@ -94,7 +96,29 @@ export const initAnon = async ( passedStore ) =>
     try
     {
         // does it matter if we override?
-        peruseAppObj = await initialiseApp( APP_INFO.info, null, appOptions );
+        const networkStateCb = (state) => {
+          // Based on latest updates in safe_app_nodes, I should at least see this callback called once, when network connection changes from INIT to CONNECTED.
+          logger.info('net callback state: ', state);
+          store.dispatch( peruseAppActions.setNetworkStatus( state ) );
+          if(state === SAFE.NETWORK_STATE.DISCONNECTED)
+          {
+            if(store)
+            {
+              store.dispatch( notificationActions.addNotification(
+                {
+                  text: `Network state: ${state}. Reconnecting...`,
+                  type: 'error',
+                  onDismiss: notificationActions.clearNotification
+                } 
+              ));
+            }
+          }
+          if(state === SAFE.NETWORK_STATE.CONNECTED && store.getState().peruseApp.networkState === SAFE.NETWORK_STATE.DISCONNECTED)
+          {
+            store.dispatch(notificationActions.clearNotification()); 
+          }
+        };
+        peruseAppObj = await initialiseApp( APP_INFO.info, networkStateCb, appOptions );
         const authReq = await peruseAppObj.auth.genConnUri( {} );
 
         const authType = parseSafeAuthUrl( authReq.uri );

--- a/app/extensions/safe/network/authenticator-comms.js
+++ b/app/extensions/safe/network/authenticator-comms.js
@@ -34,6 +34,7 @@ export const authFromInternalResponse = async ( res, isAuthenticated ) =>
         // for webFetch app only
         peruseAppObj = await peruseAppObj.auth.loginFromUri( res );
         // When running function below, error is thrown that lib.test_simulate_network_disconnect is not a function
+        logger.info('NODE_ENV: ', process.env.NODE_ENV);
         //peruseAppObj.auth.simulateNetworkDisconnect();
     }
     catch ( err )

--- a/app/extensions/safe/test/auth/auth.spec.js
+++ b/app/extensions/safe/test/auth/auth.spec.js
@@ -3,6 +3,8 @@ import path from 'path';
 import i18n from 'i18n';
 import ffiLoader from 'extensions/safe/ffi/lib';
 import client from 'extensions/safe/ffi/authenticator';
+import { authFromInternalResponse } from 'extensions/safe/network';
+import { initialiseApp } from '@maidsafe/safe-node-app';
 import * as helper from './helper';
 
 import crypto from 'crypto';
@@ -62,6 +64,24 @@ describe( 'Authenticator functions', () =>
                     {
                         should( res ).be.String();
                         should( res.indexOf( 'safe-' ) ).be.not.equal( -1 );
+                        return resolve();
+                    } );
+            } )
+        ) );
+
+        it( 'this is a new test for disconnecting and reconnecting', () => (
+            new Promise( async ( resolve ) =>
+            {
+                const networkStateCb = (state) => {
+                  console.log('network state change'); 
+                };
+                const app = await initialiseApp( APP_INFO.info, networkStateCb, appOptions );
+                const authReq = await app.auth.genConnUri( {} );
+                client.decodeRequest( authReq )
+                    .then( async ( res ) =>
+                    {
+                        logger.info('decodeRequest response: ', res);
+                        await authFromInternalResponse(res);
                         return resolve();
                     } );
             } )


### PR DESCRIPTION
@joshuef I've confused myself while working on this task. Am I enabling reconnect for Peruse app or for authenticator?
There are a couple of comments in the changes.
- When running `app.auth.simulateNetworkDisconnect()`, error is thrown that `lib.test_simulate_network_disconnect` is not a function. Not quite sure what's going on there. I even tried making sure `NODE_ENV=test` was set.
- Based on latest updates in safe_app_nodes, I should at least see the network callback called once, when network connection changes from `INIT` to `CONNECTED`, but I don't see the redux state being updated when network callback should be called.